### PR TITLE
Allow iOS to play HLS live videos

### DIFF
--- a/packages/video_player/video_player/ios/Classes/FLTVideoPlayerPlugin.m
+++ b/packages/video_player/video_player/ios/Classes/FLTVideoPlayerPlugin.m
@@ -313,9 +313,9 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
       return;
     }
     // The player may be initialized but still needs to determine the duration.
-    if ([self duration] == 0) {
-      return;
-    }
+    //if ([self duration] == 0) {
+    //  return;
+    //}
 
     _isInitialized = true;
     _eventSink(@{


### PR DESCRIPTION
Live videos have a duration of 0, and this is preventing the player to start properly.

## Description

*Replace this paragraph with a description of what this PR is doing. If you're modifying existing behavior, describe the existing behavior, how this PR is changing it, and what motivated the change.*
